### PR TITLE
Fix DataFrame cleaning and stabilize tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/src/services/excel_service.py
+++ b/src/services/excel_service.py
@@ -96,19 +96,19 @@ class ExcelService:
         Returns:
             Cleaned DataFrame
         """
-        # Remove completely empty rows
-        df = df.dropna(how='all')
-        
-        # Strip whitespace from string columns
-        string_columns = df.select_dtypes(include=['object']).columns
-        df[string_columns] = df[string_columns].astype(str).apply(lambda x: x.str.strip())
-        
-        # Replace 'nan' strings with actual NaN
-        df = df.replace('nan', pd.NA)
-        
-        # Clean column names
+        # Clean column names first for consistent access
         df.columns = [str(col).strip() for col in df.columns]
-        
+
+        # Trim whitespace from string cells
+        obj_cols = df.select_dtypes(include="object").columns
+        df[obj_cols] = df[obj_cols].apply(lambda c: c.astype(str).str.strip())
+
+        # Normalize placeholders for missing values
+        df[obj_cols] = df[obj_cols].replace(r"(?i)^\s*(?:nan|none)?\s*$", pd.NA, regex=True)
+
+        # Drop rows that are entirely empty after normalization
+        df.dropna(how="all", inplace=True)
+
         return df
     
     def get_file_hash(self, file_data: bytes) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+# Ensure the project root is on the Python path for src imports
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+


### PR DESCRIPTION
## Summary
- improve ExcelService DataFrame cleaning to drop blank rows reliably
- add pytest.ini and conftest to isolate tests and ensure `src` imports

## Testing
- `pytest -q`
- `python -m py_compile src/services/excel_service.py tests/conftest.py`
- `pip install flake8` *(fails: Could not find a version...)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d8b047188326851331df64e01c04